### PR TITLE
Convert color names to hex when exporting theme.

### DIFF
--- a/qutebrowser.el
+++ b/qutebrowser.el
@@ -539,8 +539,9 @@ TARGET specifies where to open it, or `qutebrowser-default-open-target' if nil."
              (emacs-face (cdr mapping))
              (is-fg (string-match-p "\\.fg$" qute-face))
              (attribute (if is-fg :foreground :background))
-             (color (face-attribute emacs-face attribute nil 'default)))
-        (insert (format "c.colors.%s = '%s'\n" qute-face color))))
+             (color (face-attribute emacs-face attribute nil 'default))
+             (rgb (apply #'color-rgb-to-hex `(,@(color-name-to-rgb color) 2))))
+        (insert (format "c.colors.%s = '%s'\n" qute-face rgb))))
     (write-file "~/.config/qutebrowser/emacs_theme.py")))
 
 (defun qutebrowser-theme-export-and-apply (&rest _)


### PR DESCRIPTION
Some colors get exported as names, e.g. `grey50`. These have to be converted to hex so that qutebrowser could use them.