### PR TITLE
Overwrite Python backend files if they already exist

### DIFF
--- a/qutebrowser.el
+++ b/qutebrowser.el
@@ -771,7 +771,8 @@ updated it is recommended to run this function when loading the package."
   (dolist (file '("emacs_ipc.py"
                   "emacs_hooks.py"))
     (copy-file (expand-file-name file qutebrowser--package-directory)
-               (expand-file-name file qutebrowser-config-directory))))
+               (expand-file-name file qutebrowser-config-directory)
+	       'overwrite)))
 
 (defun qutebrowser-rpc-request-window-info ()
   "Request window-info from Qutebrowser.


### PR DESCRIPTION
Using the function `qutebrowser-rpc-ensure-installed` when loading the package as directed results in a warning if the Python backend files are already installed. This PR overwrites them so that they are always up-to-date.