### PR TITLE
Change Evil state mapping for caret mode

### DIFF
--- a/qutebrowser-evil.el
+++ b/qutebrowser-evil.el
@@ -29,7 +29,7 @@
 
 (defvar qutebrowser-evil-state-mappings
   '(("KeyMode.insert" . evil-insert-state)
-    ("KeyMode.caret" . evil-visual-state)
+    ("KeyMode.caret" . evil-visual-char)
     ("KeyMode.hint" . evil-motion-state)
     ("KeyMode.command" . evil-emacs-state)
     ("KeyMode.normal" . evil-normal-state)))


### PR DESCRIPTION
The current mapping from caret mode to `evil-visual-state` breaks Evil's state tag in the mode line. The tag expects one of the visual 'sub-states' (char, line, or block). This PR changes the mapping to `evil-visual-char`.