### PR TITLE
Evil state mapping fixes

### DIFF
--- a/qutebrowser-evil.el
+++ b/qutebrowser-evil.el
@@ -41,10 +41,9 @@
               (buffer (exwm--id->buffer x11-win-id)))
     (with-current-buffer buffer
       (qutebrowser--with-plist-key mode window-info
-        (if-let ((func (alist-get mode qutebrowser-evil-state-mappings
-				  nil nil 'string-equal)))
-	    (funcall func)
-	  (evil-operator-state))))))
+        (let ((func (alist-get mode qutebrowser-evil-state-mappings
+                               'evil-operator-state nil 'string-equal)))
+          (funcall func))))))
 
 ;;;###autoload
 (define-minor-mode qutebrowser-evil-state-mode

--- a/qutebrowser-evil.el
+++ b/qutebrowser-evil.el
@@ -33,9 +33,7 @@
     ("KeyMode.hint" . evil-motion-state)
     ("KeyMode.command" . evil-emacs-state)
     ("KeyMode.normal" . evil-normal-state)
-    ("KeyMode.passthrough" . evil-emacs-state)
-    ("KeyMode.yesno" . evil-operator-state)
-    ("KeyMode.prompt" . evil-operator-state)))
+    ("KeyMode.passthrough" . evil-emacs-state)))
 
 (defun qutebrowser-evil-update-state (window-info)
   "Set evil state to match Qutebrowser keymode from WINDOW-INFO."
@@ -43,9 +41,10 @@
               (buffer (exwm--id->buffer x11-win-id)))
     (with-current-buffer buffer
       (qutebrowser--with-plist-key mode window-info
-        (when-let ((func (alist-get mode qutebrowser-evil-state-mappings
-				    nil nil 'string-equal)))
-	  (funcall func))))))
+        (if-let ((func (alist-get mode qutebrowser-evil-state-mappings
+				  nil nil 'string-equal)))
+	    (funcall func)
+	  (evil-operator-state))))))
 
 ;;;###autoload
 (define-minor-mode qutebrowser-evil-state-mode

--- a/qutebrowser-evil.el
+++ b/qutebrowser-evil.el
@@ -32,7 +32,10 @@
     ("KeyMode.caret" . evil-visual-char)
     ("KeyMode.hint" . evil-motion-state)
     ("KeyMode.command" . evil-emacs-state)
-    ("KeyMode.normal" . evil-normal-state)))
+    ("KeyMode.normal" . evil-normal-state)
+    ("KeyMode.passthrough" . evil-emacs-state)
+    ("KeyMode.yesno" . evil-operator-state)
+    ("KeyMode.prompt" . evil-operator-state)))
 
 (defun qutebrowser-evil-update-state (window-info)
   "Set evil state to match Qutebrowser keymode from WINDOW-INFO."

--- a/qutebrowser-evil.el
+++ b/qutebrowser-evil.el
@@ -40,9 +40,9 @@
               (buffer (exwm--id->buffer x11-win-id)))
     (with-current-buffer buffer
       (qutebrowser--with-plist-key mode window-info
-        (let ((func (alist-get mode qutebrowser-evil-state-mappings
-                               nil nil 'string-equal)))
-          (funcall func))))))
+        (when-let ((func (alist-get mode qutebrowser-evil-state-mappings
+				    nil nil 'string-equal)))
+	  (funcall func))))))
 
 ;;;###autoload
 (define-minor-mode qutebrowser-evil-state-mode


### PR DESCRIPTION
This PR adds missing state mappings for `KeyMode.passthrough`, `KeyMode.yesno`, and `KeyMode.prompt`. Additionally, the `let` binding in `qutebrowser-evil-update-state` is changed to `when-let`; in the case where a mapping is not found this prevents the function from trying to funcall `nil`.