### PR TITLE
Add `qutebrowser-consult.el`

### DIFF
--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -23,6 +23,9 @@
 ;; added as additional sources to 'consult-buffer' or similar. See
 ;; 'consult-buffer-sources' and 'consult--multi'.
 
+;; To use Consult for all Qutebrowser-related selection, set
+;; `qutebrowser-selection-function' to `qutebrowser-consult-select-url'.
+
 ;;; Change Log:
 
 ;;; Code:
@@ -67,7 +70,8 @@
         :category 'bookmark
         :face 'consult-bookmark
         :action #'qutebrowser-bookmark-jump
-        :items #'qutebrowser-bookmarks-list)
+        :items #'qutebrowser-bookmarks-list
+	:qb-tofu ?m)
   "Consult source for Qutebrowser bookmarks.")
 
 ;;;; Command source
@@ -81,7 +85,8 @@
 	:category 'other
 	:action #'qutebrowser-send-commands
         :annotate #'qutebrowser-consult--annotate
-	:items (apply-partially #'qutebrowser-command-search '(":")))
+	:items (apply-partially #'qutebrowser-command-search '(":"))
+	:qb-tofu ?c)
   "Consult source for Qutebrowser commands.")
 
 ;;;###autoload
@@ -134,87 +139,27 @@ Set initial completion input to INITIAL."
   (let ((new-source (seq-copy source)))
     (plist-put new-source :action nil)))
 
-;; NOTE does this still need to exist?
+;;;###autoload
 (defun qutebrowser-consult-select-url (&optional initial default)
-  "Dynamically select a URL, buffer, or command using consult.
-INITIAL sets the initial input in the minibuffer."
-  (let ((consult-async-min-input 0)
-        (consult-async-split-style nil)
-	(sources (list qutebrowser-consult--exwm-buffer-source
-		       qutebrowser-consult--bookmark-source
-		       qutebrowser-consult--history-source
-		       qutebrowser-consult--command-source)))
-    (consult--multi (mapcar #'qutebrowser-consult--suppress-action sources)
-		    :prompt (if default
-				(format "Select (default %s): " default)
-			      "Select: ")
-		    :default default
-		    :sort nil
-		    :initial initial
-		    :require-match nil)))
-
-;;;###autoload
-(defun qutebrowser-consult-launcher (&optional initial target)
-  "Select a URL to open in Qutebrowser using Consult.
-
-Set initial completion input to INITIAL. Open the URL in TARGET or the
-default target if nil.
-
-Modify `qutebrowser-consult-launcher-sources' to change which sources
-are included."
-  (interactive)
-  (let* ((consult-async-split-style nil)
-	 (qutebrowser-default-open-target (or target qutebrowser-default-open-target))
-	 (selected (consult--multi qutebrowser-consult-launcher-sources
-				   :initial initial
-				   :sort nil)))
-    (unless (plist-get (cdr selected) :match)
-      (qutebrowser-open-url (car selected)))))
-
-;;;###autoload
-(defun qutebrowser-consult-launcher-tab (&optional initial)
-  "Select a URL to open in a new tab using Consult.
-
-Set initial completion input to INITIAL.
-Modify `qutebrowser-consult-launcher-sources' to change which sources
-are included."
-  (interactive)
-  (qutebrowser-consult-launcher initial 'tab))
-
-;;;###autoload
-(defun qutebrowser-consult-launcher-window (&optional initial)
-  "Select a URL to open in a new window using Consult.
-
-Set initial completion input to INITIAL.
-Modify `qutebrowser-consult-launcher-sources' to change which sources
-are included."
-  (interactive)
-  (qutebrowser-consult-launcher initial 'window))
-
-;;;###autoload
-(defun qutebrowser-consult-launcher-private (&optional initial)
-  "Select a URL to open in a private window using Consult.
-
-Set initial completion input to INITIAL.
-Modify `qutebrowser-consult-launcher-sources' to change which sources
-are included."
-  (interactive)
-  (qutebrowser-consult-launcher initial 'private-window))
-
-(define-minor-mode qutebrowser-consult-mode
-  "Use Consult for Qutebrowser completion."
-  :lighter nil
-  :global t
-  (if qutebrowser-consult-mode
-      (progn
-	(advice-add 'qutebrowser-launcher :override #'qutebrowser-consult-launcher)
-	(advice-add 'qutebrowser-launcher-tab :override #'qutebrowser-consult-launcher-tab)
-	(advice-add 'qutebrowser-launcher-window :override #'qutebrowser-consult-launcher-window)
-	(advice-add 'qutebrowser-launcher-private :override #'qutebrowser-consult-launcher-private))
-    (advice-remove 'qutebrowser-launcher #'qutebrowser-consult-launcher)
-    (advice-remove 'qutebrowser-launcher-tab #'qutebrowser-consult-launcher-tab)
-    (advice-remove 'qutebrowser-launcher-window #'qutebrowser-consult-launcher-window)
-    (advice-remove 'qutebrowser-launcher-private #'qutebrowser-consult-launcher-private)))
+  "Backend for `qutebrowser-select-url' based on Consult."
+  (let* ((consult-async-min-input 0)
+         (consult-async-split-style nil)
+	 (sources (list qutebrowser-consult--exwm-buffer-source
+			qutebrowser-consult--bookmark-source
+			qutebrowser-consult--history-source
+			qutebrowser-consult--command-source))
+	 (selection (consult--multi
+		     (mapcar #'qutebrowser-consult--suppress-action sources)
+		     :prompt (if default
+				 (format "Select (default %s): " default)
+			       "Select: ")
+		     :default default
+		     :sort nil
+		     :initial initial
+		     :require-match nil)))
+    ;; Because `qutebrowser' still needs tofus for dispatching, we have to add them here.
+    (qutebrowser--tofu-append (car selection)
+			      (plist-get (cdr selection) :qb-tofu))))
 
 (provide 'qutebrowser-consult)
 

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -1,6 +1,6 @@
 ;;; qutebrowser-consult.el --- Consult completion for Qutebrowser -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024 Isaac Haller & Lars Rustand.
+;; Copyright (C) 2025 Isaac Haller & Lars Rustand.
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -1,0 +1,94 @@
+;;; qutebrowser-consult.el --- Consult completion for Qutebrowser -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024 Isaac Haller & Lars Rustand.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program; if not, write to the Free Software
+;; Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+;;; Commentary:
+
+;; Consult-based completion for Qutebrowser buffers, history,
+;; commands, and bookmarks.
+
+;;; Change Log:
+
+;;; Code:
+(require 'qutebrowser)
+(require 'consult)
+
+;;;; Helper functions
+(defun qutebrowser-consult--tofu-strip-lines (lines)
+  "Strip tofus from LINES."
+  (mapcar #'qutebrowser--tofu-strip lines))
+
+;;;; Buffer source
+(defvar qutebrowser-consult--exwm-buffer-source
+  (list :name "Qutebrowser buffers"
+        :hidden nil
+        :narrow ?q
+        :history nil
+        :category 'other
+        :action (lambda (entry)
+		  (switch-to-buffer (qutebrowser--tofu-get-buffer entry)))
+        :annotate #'qutebrowser-annotate
+        :items #'qutebrowser-exwm-buffer-search)
+  "Consult source for open Qutebrowser windows.")
+
+;;;; Bookmark source
+(defvar qutebrowser-consult--bookmark-source
+  (list :name "Qutebrowser bookmarks"
+        :hidden nil
+        :narrow ?m
+        :history nil
+        :category 'bookmark
+        :face 'consult-bookmark
+        :action #'qutebrowser-bookmark-jump
+        :items #'qutebrowser-bookmarks-list)
+  "Consult source for Qutebrowser bookmarks.")
+
+;;;; Command source
+(defvar qutebrowser-consult--command-history nil)
+
+(defvar qutebrowser-consult--command-source
+  (list :name "Qutebrowser commands"
+	:hidden nil
+	:narrow ?:
+	:history nil
+	:category 'other
+	:action #'qutebrowser-send-commands
+	:async
+	(consult--async-pipeline
+	 (consult--async-min-input 0)
+	 (consult--async-throttle)
+	 (consult--async-dynamic (lambda (input)
+				   (let ((words (string-split (or input ""))))
+				     (qutebrowser-command-search words))))
+	 (consult--async-transform #'qutebrowser-consult--tofu-strip-lines)))
+  "Consult source for Qutebrowser commands.")
+
+(defun qutebrowser-consult-command ()
+  "Command entry for Qutebrowser based on Consult."
+  (interactive)
+  (let* ((consult-async-min-input 0)
+	 (consult-async-split-style nil)
+	 (selected (consult--multi '(qutebrowser-consult--command-source)
+				   :prompt "Command: "
+				   :initial ":"
+				   :history 'qutebrowser-consult--command-history)))
+    (unless (plist-get (cdr selected) :match)
+      (qutebrowser-send-commands (car selected)))))
+
+(provide 'qutebrowser-consult)
+
+;;; qutebrowser-consult.el ends here

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -37,7 +37,7 @@
 ;;;; Helper functions
 (defun qutebrowser-consult--format-entry (entry)
   "Modify ENTRY for presentation."
-  (qutebrowser--shorten-display-url (qutebrowser--tofu-strip entry)))
+  (qutebrowser--shorten-display-url entry))
 
 (defun qutebrowser-consult--annotate (entry)
   "Return annotation for ENTRY."
@@ -81,9 +81,8 @@
 	:category 'other
 	:action #'qutebrowser-send-commands
         :annotate #'qutebrowser-consult--annotate
-	:items (lambda () (mapcar #'qutebrowser--tofu-strip
-				  (qutebrowser-command-search '(":"))))
-	"Consult source for Qutebrowser commands."))
+	:items (apply-partially #'qutebrowser-command-search '(":")))
+  "Consult source for Qutebrowser commands.")
 
 ;;;###autoload
 (defun qutebrowser-consult-command (&optional initial)

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -81,15 +81,9 @@
 	:category 'other
 	:action #'qutebrowser-send-commands
         :annotate #'qutebrowser-consult--annotate
-	:async
-	(consult--dynamic-collection
-	    (lambda (input)
-	      (qutebrowser-command-search (string-split (or input ""))))
-	  :min-input 0
-	  :throttle 0
-	  :debounce 0
-	  :transform (consult--async-map #'qutebrowser-consult--format-entry)))
-  "Consult source for Qutebrowser commands.")
+	:items (lambda () (mapcar #'qutebrowser--tofu-strip
+				  (qutebrowser-command-search '(":"))))
+	"Consult source for Qutebrowser commands."))
 
 ;;;###autoload
 (defun qutebrowser-consult-command (&optional initial)

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -113,6 +113,7 @@ Set initial completion input to INITIAL."
 	:history nil
 	:category 'url
 	:action #'qutebrowser-open-url
+	:new #'qutebrowser-open-url
 	:annotate #'qutebrowser-consult--annotate
 	:async
 	(consult--dynamic-collection

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -53,6 +53,12 @@
   (propertize (get-text-property 0 'title entry)
 	      'face 'completions-annotations))
 
+(defun qutebrowser-consult--format-buffer (entry)
+  "Format buffer ENTRY for completion."
+  (let ((title (get-text-property 0 'title entry)))
+    (concat (qutebrowser--shorten-display-url entry)
+	    (propertize title 'invisible t))))
+
 ;;;; Buffer source
 (defvar qutebrowser-consult--exwm-buffer-source
   (list :name "Qutebrowser buffers"
@@ -63,7 +69,7 @@
         :action (lambda (entry)
 		  (switch-to-buffer (get-text-property 0 'qutebrowser-buffer entry)))
         :annotate #'qutebrowser-consult--annotate
-        :items (lambda () (mapcar #'qutebrowser--shorten-display-url (qutebrowser-exwm-buffer-search))))
+        :items (lambda () (mapcar #'qutebrowser-consult--format-buffer (qutebrowser-exwm-buffer-search))))
   "Consult source for open Qutebrowser windows.")
 
 ;;;; Bookmark source

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -39,7 +39,7 @@
 
 (defcustom qutebrowser-consult-launcher-sources
   '(qutebrowser-consult--exwm-buffer-source
-    qutebrowser-consult--bookmark-source
+    qutebrowser-consult--bookmark-url-source
     qutebrowser-consult--history-source
     qutebrowser-consult--command-source)
   "Sources used by `qutebrowser-launcher' and family."
@@ -75,6 +75,17 @@
         :category 'bookmark
         :face 'consult-bookmark
         :action #'qutebrowser-bookmark-jump
+	:annotate #'qutebrowser-consult--annotate
+        :items #'qutebrowser-bookmarks-list)
+  "Consult source for Qutebrowser bookmarks.")
+
+(defvar qutebrowser-consult--bookmark-url-source
+  (list :name "Qutebrowser bookmarks" ;; should this be named differently? it's unlikely that this source is used with the other one
+        :hidden nil
+        :narrow ?m
+        :history nil
+        :category 'url
+        :action #'qutebrowser-open-url
 	:annotate #'qutebrowser-consult--annotate
         :items #'qutebrowser-bookmark-search)
   "Consult source for Qutebrowser bookmarks.")

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -56,7 +56,7 @@
         :history nil
         :category 'url
         :action (lambda (entry)
-		  (switch-to-buffer (qutebrowser--tofu-get-buffer entry)))
+		  (switch-to-buffer (get-text-property 0 'qb-buffer entry)))
         :annotate #'qutebrowser-consult--annotate
         :items #'qutebrowser-exwm-buffer-search)
   "Consult source for open Qutebrowser windows.")
@@ -70,8 +70,8 @@
         :category 'bookmark
         :face 'consult-bookmark
         :action #'qutebrowser-bookmark-jump
-        :items #'qutebrowser-bookmarks-list
-	:qb-tofu ?m)
+	:annotate #'qutebrowser-consult--annotate
+        :items #'qutebrowser-bookmark-search)
   "Consult source for Qutebrowser bookmarks.")
 
 ;;;; Command source
@@ -85,8 +85,7 @@
 	:category 'other
 	:action #'qutebrowser-send-commands
         :annotate #'qutebrowser-consult--annotate
-	:items (apply-partially #'qutebrowser-command-search '(":"))
-	:qb-tofu ?c)
+	:items (apply-partially #'qutebrowser-command-search '(":")))
   "Consult source for Qutebrowser commands.")
 
 ;;;###autoload
@@ -158,8 +157,7 @@ Set initial completion input to INITIAL."
 		     :initial initial
 		     :require-match nil)))
     ;; Because `qutebrowser' still needs tofus for dispatching, we have to add them here.
-    (qutebrowser--tofu-append (car selection)
-			      (plist-get (cdr selection) :qb-tofu))))
+    (car selection)))
 
 (provide 'qutebrowser-consult)
 

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -225,11 +225,11 @@ are included."
   (if qutebrowser-consult-mode
       (progn
 	(advice-add 'qutebrowser-launcher :override #'qutebrowser-consult-launcher)
-	(advice-add 'qutebrowser-launcher-tab :override #'qutebrowser-consult-launcher)
+	(advice-add 'qutebrowser-launcher-tab :override #'qutebrowser-consult-launcher-tab)
 	(advice-add 'qutebrowser-launcher-window :override #'qutebrowser-consult-launcher-window)
 	(advice-add 'qutebrowser-launcher-private :override #'qutebrowser-consult-launcher-private))
     (advice-remove 'qutebrowser-launcher #'qutebrowser-consult-launcher)
-    (advice-remove 'qutebrowser-launcher-tab #'qutebrowser-consult-launcher)-tab
+    (advice-remove 'qutebrowser-launcher-tab #'qutebrowser-consult-launcher-tab)
     (advice-remove 'qutebrowser-launcher-window #'qutebrowser-consult-launcher-window)
     (advice-remove 'qutebrowser-launcher-private #'qutebrowser-consult-launcher-private)))
 

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -124,10 +124,10 @@ Set initial completion input to INITIAL."
 
 ;;;; `qutebrowser-launcher' replacement
 (defvar qutebrowser-consult-launcher-sources
-  '(qutebrowser-consult--command-source
-    qutebrowser-consult--exwm-buffer-source
+  '(qutebrowser-consult--exwm-buffer-source
     qutebrowser-consult--bookmark-source
-    qutebrowser-consult--history-source)
+    qutebrowser-consult--history-source
+    qutebrowser-consult--command-source)
   "Sources used by `qutebrowser-launcher' and family.")
 
 (defun qutebrowser-consult--suppress-action (source)
@@ -141,10 +141,10 @@ Set initial completion input to INITIAL."
 INITIAL sets the initial input in the minibuffer."
   (let ((consult-async-min-input 0)
         (consult-async-split-style nil)
-	(sources (list qutebrowser-consult--command-source
-		       qutebrowser-consult--exwm-buffer-source
+	(sources (list qutebrowser-consult--exwm-buffer-source
 		       qutebrowser-consult--bookmark-source
-		       qutebrowser-consult--history-source)))
+		       qutebrowser-consult--history-source
+		       qutebrowser-consult--command-source)))
     (consult--multi (mapcar #'qutebrowser-consult--suppress-action sources))
     :prompt (if default
                 (format "Select (default %s): " default)

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -112,7 +112,7 @@ Set initial completion input to INITIAL."
 	:narrow ?h
 	:history nil
 	:category 'url
-	:action #'qutebrowser
+	:action #'qutebrowser-open-url
 	:annotate #'qutebrowser-consult--annotate
 	:async
 	(consult--dynamic-collection

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -136,14 +136,6 @@ Set initial completion input to INITIAL."
     qutebrowser-consult--history-source)
   "Sources used by `qutebrowser-launcher' and family.")
 
-(defun qutebrowser-consult--shorten-source-name (source)
-  "Return SOURCE with shortened name.
-
-'Qutebrowser' is stripped from the front and the remaining first letter is capitalized."
-  (let ((new-source (seq-copy source))
-	(new-name (string-remove-prefix "Qutebrowser " (plist-get source :name))))
-    (plist-put new-source :name (capitalize new-name))))
-
 (defun qutebrowser-consult--suppress-action (source)
   "Return SOURCE with no action."
   (let ((new-source (seq-copy source)))
@@ -159,16 +151,14 @@ INITIAL sets the initial input in the minibuffer."
 		       qutebrowser-consult--exwm-buffer-source
 		       qutebrowser-consult--bookmark-source
 		       qutebrowser-consult--history-source)))
-    (consult--multi
-     (mapcar #'qutebrowser-consult--shorten-source-name
-	     (mapcar #'qutebrowser-consult--suppress-action sources))
-     :prompt (if default
-                 (format "Select (default %s): " default)
-               "Select: ")
-     :default default
-     :sort nil
-     :initial initial
-     :require-match nil)))
+    (consult--multi (mapcar #'qutebrowser-consult--suppress-action sources))
+    :prompt (if default
+                (format "Select (default %s): " default)
+              "Select: ")
+    :default default
+    :sort nil
+    :initial initial
+    :require-match nil)))
 
 ;;;###autoload
 (defun qutebrowser-consult-launcher (&optional initial target)
@@ -182,11 +172,9 @@ are included."
   (interactive)
   (let* ((consult-async-split-style nil)
 	 (qutebrowser-default-open-target (or target qutebrowser-default-open-target))
-	 (selected (consult--multi
-		    (mapcar #'qutebrowser-consult--shorten-source-name
-			    (mapcar #'eval qutebrowser-consult-launcher-sources))
-		    :initial initial
-		    :sort nil)))
+	 (selected (consult--multi qutebrowser-consult-launcher-sources
+				   :initial initial
+				   :sort nil)))
     (unless (plist-get (cdr selected) :match)
       (qutebrowser-open-url (car selected)))))
 

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -54,7 +54,7 @@
         :action (lambda (entry)
 		  (switch-to-buffer (get-text-property 0 'qb-buffer entry)))
         :annotate #'qutebrowser-consult--annotate
-        :items #'qutebrowser-exwm-buffer-search)
+        :items (lambda () (mapcar #'qutebrowser--shorten-display-url (qutebrowser-exwm-buffer-search))))
   "Consult source for open Qutebrowser windows.")
 
 ;;;; Bookmark source

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -99,10 +99,11 @@ Set initial completion input to INITIAL."
   (let* ((consult-async-min-input 0)
 	 (consult-async-split-style nil)
 	 (selected
-	  (consult--read (plist-get qutebrowser-consult--command-source :async)
-			 :prompt "Command: "
-			 :initial (or initial ":")
-			 :history 'qutebrowser-consult--command-history)))
+	  (consult--multi `(,(plist-put (seq-copy qutebrowser-consult--command-source)
+					:name nil))
+			  :prompt "Command: "
+			  :initial (or initial ":")
+			  :history 'qutebrowser-consult--command-history)))
     (qutebrowser-send-commands selected)))
 
 ;;;; History source

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -133,7 +133,8 @@ Set initial completion input to INITIAL."
 ;;;; `qutebrowser-launcher' replacement
 (defun qutebrowser-consult--suppress-action (source)
   "Return SOURCE with no action."
-  (let ((new-source (seq-copy source)))
+  (let* ((source (if (symbolp source) (symbol-value source) source))
+	 (new-source (seq-copy source)))
     (plist-put new-source :action nil)))
 
 ;;;###autoload
@@ -141,10 +142,7 @@ Set initial completion input to INITIAL."
   "Backend for `qutebrowser-select-url' based on Consult."
   (let* ((consult-async-min-input 0)
          (consult-async-split-style nil)
-	 (sources (list qutebrowser-consult--exwm-buffer-source
-			qutebrowser-consult--bookmark-source
-			qutebrowser-consult--history-source
-			qutebrowser-consult--command-source))
+	 (sources qutebrowser-consult-launcher-sources)
 	 (selection (consult--multi
 		     (mapcar #'qutebrowser-consult--suppress-action sources)
 		     :prompt (if default

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -128,10 +128,10 @@ Set initial completion input to INITIAL."
 
 ;;;; `qutebrowser-launcher' replacement
 (defvar qutebrowser-consult-launcher-sources
-  (list qutebrowser-consult--command-source
-	qutebrowser-consult--exwm-buffer-source
-	qutebrowser-consult--bookmark-source
-	qutebrowser-consult--history-source)
+  '(qutebrowser-consult--command-source
+    qutebrowser-consult--exwm-buffer-source
+    qutebrowser-consult--bookmark-source
+    qutebrowser-consult--history-source)
   "Sources used by `qutebrowser-launcher' and family.")
 
 (defun qutebrowser-consult--shorten-source-name (source)
@@ -182,7 +182,7 @@ are included."
 	 (qutebrowser-default-open-target (or target qutebrowser-default-open-target))
 	 (selected (consult--multi
 		    (mapcar #'qutebrowser-consult--shorten-source-name
-			    qutebrowser-consult-launcher-sources)
+			    (mapcar #'eval qutebrowser-consult-launcher-sources))
 		    :initial initial
 		    :sort nil)))
     (unless (plist-get (cdr selected) :match)

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -53,7 +53,7 @@
   (propertize (get-text-property 0 'title entry)
 	      'face 'completions-annotations))
 
-;;;; buffer source
+;;;; Buffer source
 (defvar qutebrowser-consult--exwm-buffer-source
   (list :name "Qutebrowser buffers"
         :hidden nil

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -152,7 +152,7 @@ INITIAL sets the initial input in the minibuffer."
     :default default
     :sort nil
     :initial initial
-    :require-match nil)))
+    :require-match nil))
 
 ;;;###autoload
 (defun qutebrowser-consult-launcher (&optional initial target)

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -49,13 +49,12 @@
 ;;;; Helper functions
 (defun qutebrowser-consult--annotate (entry)
   "Return annotation for ENTRY."
-  (qutebrowser--shorten-display-url entry)
-  (propertize (get-text-property 0 'title entry)
+  (propertize (get-text-property 0 'qutebrowser-title entry)
 	      'face 'completions-annotations))
 
-(defun qutebrowser-consult--format-buffer (entry)
-  "Format buffer ENTRY for completion."
-  (let ((title (get-text-property 0 'title entry)))
+(defun qutebrowser-consult--format (entry)
+  "Format ENTRY for completion."
+  (let ((title (get-text-property 0 'qutebrowser-title entry)))
     (concat (qutebrowser--shorten-display-url entry)
 	    (propertize title 'invisible t))))
 
@@ -69,7 +68,7 @@
         :action (lambda (entry)
 		  (switch-to-buffer (get-text-property 0 'qutebrowser-buffer entry)))
         :annotate #'qutebrowser-consult--annotate
-        :items (lambda () (mapcar #'qutebrowser-consult--format-buffer (qutebrowser-exwm-buffer-search))))
+        :items (lambda () (mapcar #'qutebrowser-consult--format (qutebrowser-exwm-buffer-search))))
   "Consult source for open Qutebrowser windows.")
 
 ;;;; Bookmark source
@@ -93,8 +92,8 @@
         :category 'url
         :action #'qutebrowser-open-url
 	:annotate #'qutebrowser-consult--annotate
-        :items #'qutebrowser-bookmark-search)
-  "Consult source for Qutebrowser bookmarks.")
+        :items (lambda () (mapcar #'qutebrowser-consult--format (qutebrowser-bookmark-search))))
+  "Consult source for Qutebrowser bookmark URLs.")
 
 ;;;; Command source
 (defvar qutebrowser-consult--command-history nil)

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -144,14 +144,14 @@ INITIAL sets the initial input in the minibuffer."
 		       qutebrowser-consult--bookmark-source
 		       qutebrowser-consult--history-source
 		       qutebrowser-consult--command-source)))
-    (consult--multi (mapcar #'qutebrowser-consult--suppress-action sources))
-    :prompt (if default
-                (format "Select (default %s): " default)
-              "Select: ")
-    :default default
-    :sort nil
-    :initial initial
-    :require-match nil))
+    (consult--multi (mapcar #'qutebrowser-consult--suppress-action sources)
+		    :prompt (if default
+				(format "Select (default %s): " default)
+			      "Select: ")
+		    :default default
+		    :sort nil
+		    :initial initial
+		    :require-match nil)))
 
 ;;;###autoload
 (defun qutebrowser-consult-launcher (&optional initial target)

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -106,6 +106,7 @@
 	:history nil
 	:category 'other
 	:action #'qutebrowser-send-commands
+	:new #'qutebrowser-send-commands
         :annotate #'qutebrowser-consult--annotate
 	:items (apply-partially #'qutebrowser-command-search '(":")))
   "Consult source for Qutebrowser commands.")
@@ -116,14 +117,12 @@
 Set initial completion input to INITIAL."
   (interactive)
   (let* ((consult-async-min-input 0)
-	 (consult-async-split-style nil)
-	 (selected
-	  (consult--multi '(qutebrowser-consult--command-source)
-                          :group nil
-			  :prompt "Command: "
-			  :initial (or initial ":")
-			  :history 'qutebrowser-consult--command-history)))
-    (qutebrowser-send-commands selected)))
+	 (consult-async-split-style nil))
+    (consult--multi '(qutebrowser-consult--command-source)
+                    :group nil
+		    :prompt "Command: "
+		    :initial (or initial ":")
+		    :history 'qutebrowser-consult--command-history)))
 
 ;;;; History source
 (defvar qutebrowser-consult--history-source

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -37,6 +37,15 @@
   :group 'qutebrowser
   :prefix "qutebrowser-consult")
 
+(defcustom qutebrowser-consult-launcher-sources
+  '(qutebrowser-consult--exwm-buffer-source
+    qutebrowser-consult--bookmark-source
+    qutebrowser-consult--history-source
+    qutebrowser-consult--command-source)
+  "Sources used by `qutebrowser-launcher' and family."
+  :type '(repeat symbol)
+  :group 'qutebrowser-consult)
+
 ;;;; Helper functions
 (defun qutebrowser-consult--annotate (entry)
   "Return annotation for ENTRY."
@@ -122,13 +131,6 @@ Set initial completion input to INITIAL."
   "Consult source for Qutebrowser history.")
 
 ;;;; `qutebrowser-launcher' replacement
-(defvar qutebrowser-consult-launcher-sources
-  '(qutebrowser-consult--exwm-buffer-source
-    qutebrowser-consult--bookmark-source
-    qutebrowser-consult--history-source
-    qutebrowser-consult--command-source)
-  "Sources used by `qutebrowser-launcher' and family.")
-
 (defun qutebrowser-consult--suppress-action (source)
   "Return SOURCE with no action."
   (let ((new-source (seq-copy source)))

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -152,7 +152,6 @@ Set initial completion input to INITIAL."
 		     :sort nil
 		     :initial initial
 		     :require-match nil)))
-    ;; Because `qutebrowser' still needs tofus for dispatching, we have to add them here.
     (car selection)))
 
 (provide 'qutebrowser-consult)

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -93,8 +93,8 @@ Set initial completion input to INITIAL."
   (let* ((consult-async-min-input 0)
 	 (consult-async-split-style nil)
 	 (selected
-	  (consult--multi `(,(plist-put (seq-copy qutebrowser-consult--command-source)
-					:name nil))
+	  (consult--multi '(qutebrowser-consult--command-source)
+                          :group nil
 			  :prompt "Command: "
 			  :initial (or initial ":")
 			  :history 'qutebrowser-consult--command-history)))

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -42,7 +42,7 @@
     qutebrowser-consult--bookmark-url-source
     qutebrowser-consult--history-source
     qutebrowser-consult--command-source)
-  "Sources used by `qutebrowser-launcher' and family."
+  "Sources used by `qutebrowser-consult-launcher'."
   :type '(repeat symbol)
   :group 'qutebrowser-consult)
 
@@ -85,7 +85,7 @@
   "Consult source for Qutebrowser bookmarks.")
 
 (defvar qutebrowser-consult--bookmark-url-source
-  (list :name "Qutebrowser bookmarks" ;; should this be named differently? it's unlikely that this source is used with the other one
+  (list :name "Qutebrowser bookmarks"
         :hidden nil
         :narrow ?m
         :history nil
@@ -145,21 +145,16 @@ Set initial completion input to INITIAL."
 	  :transform (consult--async-map #'qutebrowser--shorten-display-url)))
   "Consult source for Qutebrowser history.")
 
-;;;; `qutebrowser-launcher' replacement
-(defun qutebrowser-consult--suppress-action (source)
-  "Return SOURCE with no action."
-  (let* ((source (if (symbolp source) (symbol-value source) source))
-	 (new-source (seq-copy source)))
-    (plist-put new-source :action nil)))
-
+;;;; `qutebrowser-launcher' backend
 ;;;###autoload
-(defun qutebrowser-consult-select-url (&optional initial default)
-  "Backend for `qutebrowser-select-url' based on Consult."
+(defun qutebrowser-consult-launcher (&optional initial default target)
+  "Backend for `qutebrowser-launcher' based on Consult."
   (let* ((consult-async-min-input 0)
          (consult-async-split-style nil)
-	 (sources qutebrowser-consult-launcher-sources)
+	 (qutebrowser-default-open-target
+	  (or target qutebrowser-default-open-target))
 	 (selection (consult--multi
-		     (mapcar #'qutebrowser-consult--suppress-action sources)
+		     qutebrowser-consult-launcher-sources
 		     :prompt (if default
 				 (format "Select (default %s): " default)
 			       "Select: ")
@@ -167,7 +162,8 @@ Set initial completion input to INITIAL."
 		     :sort nil
 		     :initial initial
 		     :require-match nil)))
-    (car selection)))
+    (unless (plist-get (cdr selection) :match)
+      (qutebrowser-open-url (car selection)))))
 
 (provide 'qutebrowser-consult)
 

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -38,10 +38,6 @@
   :prefix "qutebrowser-consult")
 
 ;;;; Helper functions
-(defun qutebrowser-consult--format-entry (entry)
-  "Modify ENTRY for presentation."
-  (qutebrowser--shorten-display-url entry))
-
 (defun qutebrowser-consult--annotate (entry)
   "Return annotation for ENTRY."
   (qutebrowser--shorten-display-url entry)
@@ -122,7 +118,7 @@ Set initial completion input to INITIAL."
 	  :throttle 0
 	  :debounce 0
 	  :highlight t
-	  :transform (consult--async-map #'qutebrowser-consult--format-entry)))
+	  :transform (consult--async-map #'qutebrowser--shorten-display-url)))
   "Consult source for Qutebrowser history.")
 
 ;;;; `qutebrowser-launcher' replacement

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -188,7 +188,7 @@ are included."
 		    :initial initial
 		    :sort nil)))
     (unless (plist-get (cdr selected) :match)
-      (qutebrowser (car selected)))))
+      (qutebrowser-open-url (car selected)))))
 
 ;;;###autoload
 (defun qutebrowser-consult-launcher-tab (&optional initial)

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -35,10 +35,9 @@
   :prefix "qutebrowser-consult")
 
 ;;;; Helper functions
-(defun qutebrowser-consult--transform (lines)
-  "Modify LINES for presentation."
-  (mapcar #'qutebrowser--shorten-display-url
-	  (mapcar #'qutebrowser--tofu-strip lines)))
+(defun qutebrowser-consult--format-entry (entry)
+  "Modify ENTRY for presentation."
+  (qutebrowser--shorten-display-url (qutebrowser--tofu-strip entry)))
 
 (defun qutebrowser-consult--annotate (entry)
   "Return annotation for ENTRY."
@@ -89,7 +88,7 @@
 	  :min-input 0
 	  :throttle 0
 	  :debounce 0
-	  :transform (consult--async-transform #'qutebrowser-consult--transform)))
+	  :transform (consult--async-map #'qutebrowser-consult--format-entry)))
   "Consult source for Qutebrowser commands.")
 
 ;;;###autoload
@@ -124,7 +123,7 @@ Set initial completion input to INITIAL."
 	  :throttle 0
 	  :debounce 0
 	  :highlight t
-	  :transform (consult--async-transform #'qutebrowser-consult--transform)))
+	  :transform (consult--async-map #'qutebrowser-consult--format-entry)))
   "Consult source for Qutebrowser history.")
 
 ;;;; `qutebrowser-launcher' replacement

--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -61,7 +61,7 @@
         :history nil
         :category 'url
         :action (lambda (entry)
-		  (switch-to-buffer (get-text-property 0 'qb-buffer entry)))
+		  (switch-to-buffer (get-text-property 0 'qutebrowser-buffer entry)))
         :annotate #'qutebrowser-consult--annotate
         :items (lambda () (mapcar #'qutebrowser--shorten-display-url (qutebrowser-exwm-buffer-search))))
   "Consult source for open Qutebrowser windows.")

--- a/qutebrowser.el
+++ b/qutebrowser.el
@@ -217,6 +217,13 @@ query is built, see `qutebrowser--history-search'."
   :type 'boolean
   :group 'qutebrowser)
 
+(defcustom qutebrowser-selection-function #'qutebrowser-select-url-completing-read
+  "The default function to use when selecting a URL, buffer, bookmark, or command."
+  :type '(choice (const :tag "Built-in" qutebrowser-select-url-completing-read)
+		 (const :tag "Consult" qutebrowser-consult-select-url)
+		 (function :tag "Custom command"))
+  :group 'qutebrowser)
+
 (defcustom qutebrowser-history-order-by "last_atime DESC"
   "How to sort the history entries in the completion lists."
   :type '(choice
@@ -839,14 +846,18 @@ than `qutebrowser-url-display-length'."
     (dolist (table '("CompletionHistory" "History"))
       (sqlite-execute qutebrowser--db-object (format query table) (list url)))))
 
-(defun qutebrowser-select-url (&optional initial default)
-  "Dynamically select a URL, buffer, or command.
-INITIAL sets the initial input in the minibuffer."
+(defun qutebrowser-select-url-completing-read (&optional initial default)
+  "Backend for `qutebrowser-select-url' based on `completing-read'."
   (setq qutebrowser-launcher--current-input "")
   (let ((prompt (if default
                     (format "Select (default %s): " default)
                   "Select: ")))
     (completing-read prompt #'qutebrowser--completion-table nil nil initial nil default)))
+
+(defun qutebrowser-select-url (&optional initial default)
+  "Dynamically select a URL, buffer, or command.
+INITIAL sets the initial input in the minibuffer."
+  (funcall qutebrowser-selection-function initial default))
 
 ;;;; Launcher functions
 

--- a/qutebrowser.el
+++ b/qutebrowser.el
@@ -528,8 +528,7 @@ Return up to LIMIT results."
     (mapcar (lambda (row)
               (let* ((url (car row))
                      (title (cadr row)))
-                (propertize (qutebrowser--tofu-append url ?h)
-                            'title title)))
+                (propertize url 'title title)))
             rows)))
 
 ;;;; Utility functions
@@ -606,6 +605,12 @@ than `qutebrowser--tofu-range'."
                (setq id (char-to-string (+ qutebrowser--tofu-char id)))
                (propertize id 'invisible t)))
            id-list)))
+
+(defsubst qutebrowser--tofu-append-to-list (cands &rest id-list)
+  "Append tofu-encoded IDs from ID-LIST to CANDS.
+See `qutebrowser--tofu-append'."
+  (mapcar (lambda (cand) (apply #'qutebrowser--tofu-append cand id-list))
+	  cands))
 
 (defsubst qutebrowser--tofu-get (cand &optional pos)
   "Extract tofu-encoded ID from CAND.
@@ -691,8 +696,7 @@ all the words in WORDS in any of the fields retrieved by FIELD-GETTERS."
           (format qutebrowser-heading-bookmark matches))
     (mapcar (lambda (bookmark)
               (let* ((url (qutebrowser-bookmark-url bookmark)))
-                (propertize (qutebrowser--tofu-append url ?m)
-                            'title bookmark)))
+                (propertize url 'title bookmark)))
             matching-bookmarks)))
 
 (defun qutebrowser-exwm-buffer-search (&optional words)
@@ -739,7 +743,7 @@ all the words in WORDS in any of the fields retrieved by FIELD-GETTERS."
        (lambda (cmd)
          (let ((name (concat ":" (plist-get cmd :command)))
                (desc (car (string-lines (plist-get cmd :description)))))
-           (propertize (qutebrowser--tofu-append name ?c) 'title desc 'url name)))
+           (propertize name 'title desc 'url name)))
        matching-commands))))
 
 (defun qutebrowser--highlight-matches (words str)
@@ -821,10 +825,11 @@ than `qutebrowser-url-display-length'."
       (setq qutebrowser-launcher--current-input string))
     (let ((words (string-split (or string ""))))
       (append
-       (qutebrowser-command-search words)
+       (qutebrowser--tofu-append-to-list (qutebrowser-command-search words) ?c)
        (qutebrowser-exwm-buffer-search words)
-       (qutebrowser-bookmark-search words)
-       (qutebrowser--history-search words qutebrowser-dynamic-results)))))
+       (qutebrowser--tofu-append-to-list (qutebrowser-bookmark-search words) ?m)
+       (qutebrowser--tofu-append-to-list
+	(qutebrowser--history-search words qutebrowser-dynamic-results) ?h)))))
 
 ;;;###autoload
 (defun qutebrowser-delete-from-history (url)

--- a/qutebrowser.el
+++ b/qutebrowser.el
@@ -567,10 +567,7 @@ Return up to LIMIT results."
 
 (defun qutebrowser-exwm-buffer-url (&optional buffer)
   "Return the URL of BUFFER or the current buffer."
-  (with-current-buffer (or buffer (current-buffer))
-    (or qutebrowser-exwm-current-url
-        ;; Keep backward compatibility for now
-        (get-text-property 0 'qutebrowser-url (buffer-name buffer)))))
+  (buffer-local-value 'qutebrowser-exwm-current-url (or buffer (current-buffer))))
 
 (defun qutebrowser-exwm-buffer-list ()
   "Return a list of all Qutebrowser buffers."
@@ -696,7 +693,7 @@ all the words in WORDS in any of the fields retrieved by FIELD-GETTERS."
        (lambda (cmd)
          (let ((name (concat ":" (plist-get cmd :command)))
                (desc (car (string-lines (plist-get cmd :description)))))
-           (propertize name 'qutebrowser-candidate-type 'command 'qutebrowser-title desc 'qutebrowser-url name)))
+           (propertize name 'qutebrowser-candidate-type 'command 'qutebrowser-title desc)))
        matching-commands))))
 
 (defun qutebrowser--highlight-matches (words str)

--- a/qutebrowser.el
+++ b/qutebrowser.el
@@ -535,7 +535,7 @@ Return up to LIMIT results."
     (mapcar (lambda (row)
               (let* ((url (car row))
                      (title (cadr row)))
-                (propertize url 'qutebrowser-candidate-type 'url 'title title)))
+                (propertize url 'qutebrowser-candidate-type 'url 'qutebrowser-title title)))
             rows)))
 
 ;;;; Utility functions
@@ -570,7 +570,7 @@ Return up to LIMIT results."
   (with-current-buffer (or buffer (current-buffer))
     (or qutebrowser-exwm-current-url
         ;; Keep backward compatibility for now
-        (get-text-property 0 'url (buffer-name buffer)))))
+        (get-text-property 0 'qutebrowser-url (buffer-name buffer)))))
 
 (defun qutebrowser-exwm-buffer-list ()
   "Return a list of all Qutebrowser buffers."
@@ -649,7 +649,7 @@ all the words in WORDS in any of the fields retrieved by FIELD-GETTERS."
           (format qutebrowser-heading-bookmark matches))
     (mapcar (lambda (bookmark)
               (let* ((url (qutebrowser-bookmark-url bookmark)))
-                (propertize url 'qutebrowser-candidate-type 'bookmark 'title bookmark)))
+                (propertize url 'qutebrowser-candidate-type 'bookmark 'qutebrowser-title bookmark)))
             matching-bookmarks)))
 
 (defun qutebrowser-exwm-buffer-search (&optional words)
@@ -673,9 +673,9 @@ all the words in WORDS in any of the fields retrieved by FIELD-GETTERS."
                 (propertize url
 			    'qutebrowser-candidate-type 'buffer
 			    'qutebrowser-buffer buffer
-                            'title (if qutebrowser-launcher-show-icons
-                                       (concat icon-string " " title)
-                                     title))))
+                            'qutebrowser-title (if qutebrowser-launcher-show-icons
+						   (concat icon-string " " title)
+						 title))))
             matching-buffers)))
 
 
@@ -696,7 +696,7 @@ all the words in WORDS in any of the fields retrieved by FIELD-GETTERS."
        (lambda (cmd)
          (let ((name (concat ":" (plist-get cmd :command)))
                (desc (car (string-lines (plist-get cmd :description)))))
-           (propertize name 'qutebrowser-candidate-type 'command 'title desc 'url name)))
+           (propertize name 'qutebrowser-candidate-type 'command 'qutebrowser-title desc 'qutebrowser-url name)))
        matching-commands))))
 
 (defun qutebrowser--highlight-matches (words str)
@@ -722,7 +722,7 @@ hidden by setting the `invisible' property.
 If PAD is non-nil, add padding to the annotation if ENTRY is shorter
 than `qutebrowser-url-display-length'."
   (let ((input qutebrowser-launcher--current-input)
-        (title (get-text-property 0 'title entry)))
+        (title (get-text-property 0 'qutebrowser-title entry)))
     ;; Set main face of annotation (title)
     (put-text-property 0 (length title) 'face 'completions-annotations title)
     ;; Highlight all matching words (both in url and title)

--- a/qutebrowser.el
+++ b/qutebrowser.el
@@ -807,7 +807,7 @@ INITIAL sets the initial input in the minibuffer."
 ;;;; Launcher functions
 
 ;;;###autoload
-(defun qutebrowser (thing &optional target count)
+(defun qutebrowser (thing &optional target)
   "Do THING in Qutebrowser.
 
 THING can be one of: a URL, a Qutebrowser buffer, a Qutebrowser command
@@ -819,16 +819,12 @@ TARGET is where to do the thing, and can be one of: 'auto, 'tab,
 `qutebrowser-default-open-target'. When THING is a buffer or a command,
 TARGET is ignored.
 
-If THING is a Qutebrowser command, COUNT is passed directly to the
-command. Otherwise THING is done COUNT times.
-
 If called interactively, prompts for input with dynamic completion from
 Qutebrowser history, open Qutebrowser buffers, Qutebrowser bookmarks,
 and, if input starts with a colon, known Qutebrowser commands.
 
 With one universal argument, set TARGET to 'tab.
-With two universal arguments, set TARGET to 'private-window.
-With a numeric prefix argument N, set COUNT to N."
+With two universal arguments, set TARGET to 'private-window."
   (interactive (list (let ((default
                             (or (and (region-active-p)
                                      (filter-buffer-substring
@@ -843,16 +839,10 @@ With a numeric prefix argument N, set COUNT to N."
                        ('(16) 'private-window)
                        (_ nil))
                      (and (numberp current-prefix-arg)
-                          current-prefix-arg)))
-  (let ((cand-type (get-text-property 0 'qutebrowser-candidate-type thing))
-        (buffer (get-text-property 0 'qutebrowser-buffer thing)))
-    (cond
-     ((eq 'buffer cand-type) (switch-to-buffer buffer))
-     ((eq 'command cand-type) (qutebrowser-send-commands thing))
-     (t (qutebrowser-open-url thing target)))))
+                          current-prefix-arg))))
 
 ;;;###autoload
-(defun qutebrowser-dwim (thing &optional target count)
+(defun qutebrowser-dwim (thing &optional target)
   (interactive (list (or (and (region-active-p)
                               (filter-buffer-substring
                                (region-beginning)
@@ -864,10 +854,8 @@ With a numeric prefix argument N, set COUNT to N."
                      (pcase current-prefix-arg
                        ('(4) 'tab)
                        ('(16) 'private-window)
-                       (_ nil))
-                     (and (numberp current-prefix-arg)
-                          current-prefix-arg)))
-  (qutebrowser thing target count))
+                       (_ nil))))
+  (qutebrowser thing target))
 
 ;;;###autoload
 (defun qutebrowser-launcher (&optional initial target)

--- a/qutebrowser.el
+++ b/qutebrowser.el
@@ -535,7 +535,7 @@ Return up to LIMIT results."
     (mapcar (lambda (row)
               (let* ((url (car row))
                      (title (cadr row)))
-                (propertize url 'qb-type 'url 'title title)))
+                (propertize url 'qutebrowser-candidate-type 'url 'title title)))
             rows)))
 
 ;;;; Utility functions
@@ -649,7 +649,7 @@ all the words in WORDS in any of the fields retrieved by FIELD-GETTERS."
           (format qutebrowser-heading-bookmark matches))
     (mapcar (lambda (bookmark)
               (let* ((url (qutebrowser-bookmark-url bookmark)))
-                (propertize url 'qb-type 'bookmark 'title bookmark)))
+                (propertize url 'qutebrowser-candidate-type 'bookmark 'title bookmark)))
             matching-bookmarks)))
 
 (defun qutebrowser-exwm-buffer-search (&optional words)
@@ -671,8 +671,8 @@ all the words in WORDS in any of the fields retrieved by FIELD-GETTERS."
 
                      (icon-string (propertize "" 'display icon)))
                 (propertize url
-			    'qb-type 'buffer
-			    'qb-buffer buffer
+			    'qutebrowser-candidate-type 'buffer
+			    'qutebrowser-buffer buffer
                             'title (if qutebrowser-launcher-show-icons
                                        (concat icon-string " " title)
                                      title))))
@@ -696,7 +696,7 @@ all the words in WORDS in any of the fields retrieved by FIELD-GETTERS."
        (lambda (cmd)
          (let ((name (concat ":" (plist-get cmd :command)))
                (desc (car (string-lines (plist-get cmd :description)))))
-           (propertize name 'qb-type 'command 'title desc 'url name)))
+           (propertize name 'qutebrowser-candidate-type 'command 'title desc 'url name)))
        matching-commands))))
 
 (defun qutebrowser--highlight-matches (words str)
@@ -751,7 +751,7 @@ than `qutebrowser-url-display-length'."
 (defun qutebrowser-launcher--group-entries (entry transform)
   (if transform
       entry
-    (pcase (get-text-property 0 'qb-type entry)
+    (pcase (get-text-property 0 'qutebrowser-candidate-type entry)
       ('buffer qutebrowser-heading-buffer--with-count)
       ('bookmark qutebrowser-heading-bookmark--with-count)
       ('command qutebrowser-heading-command--with-count)
@@ -844,8 +844,8 @@ With a numeric prefix argument N, set COUNT to N."
                        (_ nil))
                      (and (numberp current-prefix-arg)
                           current-prefix-arg)))
-  (let ((cand-type (get-text-property 0 'qb-type thing))
-        (buffer (get-text-property 0 'qb-buffer thing)))
+  (let ((cand-type (get-text-property 0 'qutebrowser-candidate-type thing))
+        (buffer (get-text-property 0 'qutebrowser-buffer thing)))
     (cond
      ((eq 'buffer cand-type) (switch-to-buffer buffer))
      ((eq 'command cand-type) (qutebrowser-send-commands thing))

--- a/qutebrowser.el
+++ b/qutebrowser.el
@@ -802,32 +802,6 @@ than `qutebrowser-url-display-length'."
 
 (defvar qutebrowser-launcher--current-input "")
 
-(defun qutebrowser-consult-select-url (&optional initial default)
-  "Dynamically select a URL, buffer, or command using consult.
-INITIAL sets the initial input in the minibuffer."
-  (let ((consult-async-min-input 0)
-        (consult-async-split-style nil))
-    (consult--read
-     (consult--dynamic-collection
-      (lambda (input)
-        (setq qutebrowser-launcher--current-input input)
-        (let ((words (string-split (or input ""))))
-          (append
-           (qutebrowser-command-search words)
-           (qutebrowser-exwm-buffer-search words)
-           (qutebrowser-bookmark-search words)
-           (qutebrowser--history-search words qutebrowser-dynamic-results)))))
-     :prompt (if default
-                 (format "Select (default %s): " default)
-               "Select: ")
-     :default default
-     :group #'qutebrowser-launcher--group-entries
-     :sort nil
-     :annotate (lambda (entry) (qutebrowser-annotate entry t))
-     :initial initial
-     :require-match nil)))
-
-
 (defun qutebrowser--completion-table (string predicate action)
   (if (eq action 'metadata)
       `(metadata . ((category . url)

--- a/qutebrowser.el
+++ b/qutebrowser.el
@@ -869,42 +869,6 @@ INITIAL sets the initial input in the minibuffer."
                   "Select: ")))
     (completing-read prompt #'qutebrowser--completion-table nil nil initial nil default)))
 
-
-;;;; Static consult buffer sources
-
-;; These buffer sources are not in use anymore by the launcher after
-;; it was rewritten as a dynamic consult source. However, these
-;; sources can still be used in various consult commands, and can be
-;; added as additional sources to 'consult-buffer' or similar.
-;; See 'consult-buffer-sources' and 'consult--multi'.
-
-;; The naming of these sources might indicate that they are for
-;; internal use, but that is not the case. They simply follow the
-;; naming pattern used by the official consult sources.
-
-(defvar qutebrowser--exwm-buffer-source
-  (list :name "Qutebrowser buffers"
-        :hidden nil
-        :narrow ?q
-        :history nil
-        :category 'other
-        :action (lambda (entry)
-                  (switch-to-buffer (qutebrowser--tofu-get-buffer entry)))
-        :annotate #'qutebrowser-annotate
-        :items #'qutebrowser-exwm-buffer-search)
-  "`consult-buffer' source for open Qutebrowser windows.")
-
-(defvar qutebrowser--bookmark-source
-  (list :name "Qutebrowser bookmarks"
-        :hidden nil
-        :narrow ?m
-        :history nil
-        :category 'other
-        :face 'consult-bookmark
-        :action #'qutebrowser-bookmark-jump
-        :items #'qutebrowser-bookmarks-list)
-  "`consult-buffer' source for Qutebrowser bookmarks.")
-
 ;;;; Launcher functions
 
 ;;;###autoload


### PR DESCRIPTION
We discussed adding a new `qutebrowser-consult.el` and putting the remaining Consult related code from `qutebrowser.el` there in https://github.com/lrustand/qutebrowser.el/issues/18. This PR adds a rough draft of `qutebrower-consult.el`.