### PR TITLE
Make username extractor in qutebrowser-pass configurable

### DIFF
--- a/README.org
+++ b/README.org
@@ -297,6 +297,15 @@ config.bind(',P', "spawn --userscript emacsclient-wrapper '(qutebrowser-pass-pas
 config.bind(',o', "spawn --userscript emacsclient-wrapper '(qutebrowser-pass-otp \"{url}\")'")
 #+end_src
 
+Per default =username= is expected to be the last item of a pass entry, e.g.
+=site.com/username=. In case you store =username= encrypted along the password,
+configure the username extractor accordingly:
+
+#+begin_src elisp
+(setq qutebrowser-pass--username
+      (apply-partially #'auth-source-pass-get "login"))
+#+end_src
+
 * Recommended third-party packages
 
 - vertico-posframe-mode

--- a/qutebrowser-pass.el
+++ b/qutebrowser-pass.el
@@ -27,6 +27,23 @@
 (require 'password-store-otp)
 (require 'url-parse)
 
+(defgroup qutebrowser-pass nil
+  "Password store integration for Qutebrowser."
+  :group 'qutebrowser
+  :prefix "qutebrowser-pass")
+
+(defcustom qutebrowser-pass-username-function
+  #'qutebrowser-pass-username-from-path
+  "Function to retrieve the username for a pass entry."
+  :type 'symbol
+  :group 'qutebrowser-pass)
+
+(defalias 'qutebrowser-pass-username-from-path #'file-name-nondirectory
+  "Extract username as the last path segment of FILENAME.")
+
+(defsubst qutebrowser-pass-username-from-field (field)
+  "Extract username from FIELD of a pass entry."
+  (lambda (e) (password-store-get-field e field)))
 
 (defun qutebrowser-pass--select-entry (search)
   "Select an entry from password store matching SEARCH."
@@ -57,7 +74,7 @@ one.  If there is only one matching entry it is selected automatically."
   (interactive)
   (when-let ((selected (qutebrowser-pass--select-entry search)))
     (unless (eq :password-only limit)
-      (let ((username (car (last (string-split selected "/")))))
+      (let ((username (funcall qutebrowser-pass-username-function selected)))
         (qutebrowser-fake-keys username)))
     ;; Only tab when inputting both username and password
     (unless limit (qutebrowser-fake-keys--raw "<Tab>"))


### PR DESCRIPTION
there are many ways how password store could be organised. I store username in the pass file itself, titled `login`. This PR lets the user configure the way the username is extracted.

Also, consider replacing `password-store` uses with `auth-source-pass` which is shipped with emacs starting from 27.1