### PR TITLE
Eval 'emacs' command in the source EXWM buffer.

### DIFF
--- a/emacs_rpc.py
+++ b/emacs_rpc.py
@@ -16,7 +16,9 @@ from dataclasses import dataclass
 from tempfile import mkstemp
 from typing import Sequence, Callable, Optional, Union
 
-from PyQt6.QtCore import QByteArray, pyqtSlot
+from qutebrowser.qt.core import QByteArray, pyqtSlot
+from qutebrowser.qt.widgets import QApplication
+
 from qutebrowser.api import message, cmdutils
 from qutebrowser.browser.browsertab import AbstractTab
 from qutebrowser.commands import runners
@@ -717,8 +719,11 @@ def emacs(code: str,
     """
 
     callback = print_result if show else nop
-    objreg.get("emacs-rpc").send_request("eval", {"code": code},
-                                         result_callback=callback)
+    objreg.get("emacs-rpc").send_request(
+        "eval",
+        {"code": code, "x11-win-id": int(QApplication.activeWindow().winId())},
+        result_callback=callback,
+    )
 
 
 if __name__ == "config":

--- a/qutebrowser.el
+++ b/qutebrowser.el
@@ -1132,7 +1132,11 @@ CONN is the `jsonrpc-connection' the request was received on.
 METHOD is the method that was called.
 PARAMS are the parameters given."
   (cl-case method
-    (eval (eval (read (plist-get params :code))))
+    (eval
+     (with-current-buffer
+         (or (and exwm-wm-mode (exwm--id->buffer (plist-get params :x11-win-id)))
+             (current-buffer))
+       (eval (read (plist-get params :code)))))
     (t (message "Receive request from QB: %s, %s" method params)
        "Responding from Emacs!")))
 


### PR DESCRIPTION
I thought it'd be cool if I can clone git repos while visiting them in qutebrowser.
I tried `:emacs '(magit-clone-regular "{url}" magit-clone-default-directory nil)'` and it raised an error "Selecting deleted buffer" somewhere in the internals of `magit` ([here](https://github.com/magit/magit/blob/dc0094bd88a5307fdfa1c2a48f3ec5b33891f1f0/lisp/magit-clone.el#L282-L283) to be exact). The same command works fine when executed directly in emacs. I checked `magit` sources and it seems to be saving the `(current-buffer)` before executing a command and expecting the buffer to be alive when the command finishes.

`qutebrowser-rpc--notification-dispatcher` doesn't set the current buffer explicitly, so it is the `*temp*` one set by  `jsonrpc` logic. 

I think it is favorable to use the EXWM buffer of the qutebrowser window that sent the command, so that `elisp` code is aware of the context and could do something with the buffer.