### PR TITLE
Return nil when no pass entry found.

### DIFF
--- a/qutebrowser-pass.el
+++ b/qutebrowser-pass.el
@@ -58,7 +58,8 @@
       (if (= (length pass-entries) 1)
           (car pass-entries)
         (completing-read "Select: " pass-entries))
-    (message "No pass entry found for %s" search)))
+    (message "No pass entry found for %s" search)
+    nil))
 
 ;;;###autoload
 (defun qutebrowser-pass (&optional search limit)


### PR DESCRIPTION
https://github.com/lrustand/qutebrowser.el/blob/ecf3efa6b0707d78644fca515b5df8df2635015f/qutebrowser-pass.el#L75
here it is expected that `(qutebrowser-pass--select-entry search)` returns `nil` for empty result

however the last form of `qutebrowser-pass--select-entry` is `message` which returns the printed text
https://github.com/lrustand/qutebrowser.el/blob/ecf3efa6b0707d78644fca515b5df8df2635015f/qutebrowser-pass.el#L61
