### PR TITLE
Make EXWM dependency optional

### DIFF
--- a/qutebrowser-consult.el
+++ b/qutebrowser-consult.el
@@ -38,8 +38,7 @@
   :prefix "qutebrowser-consult")
 
 (defcustom qutebrowser-consult-launcher-sources
-  '(qutebrowser-consult--exwm-buffer-source
-    qutebrowser-consult--bookmark-url-source
+  '(qutebrowser-consult--bookmark-url-source
     qutebrowser-consult--history-source
     qutebrowser-consult--command-source)
   "Sources used by `qutebrowser-consult-launcher'."

--- a/qutebrowser-exwm.el
+++ b/qutebrowser-exwm.el
@@ -1,0 +1,252 @@
+;;; qutebrowser-exwm.el --- EXWM integration for Qutebrowser     -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025 Lars Rustand.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program; if not, write to the Free Software
+;; Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+;; Author: Lars Rustand
+;; URL: https://github.com/lrustand/qutebrowser.el
+;; Package-Requires: ((emacs "29.1") (exwm "0.28"))
+
+;;; Commentary:
+
+;; This package provides EXWM-specific integration for Qutebrowser,
+;; including buffer-local variables tracking window state, favicon
+;; management, and a minor mode for Qutebrowser EXWM buffers.
+;;
+;;; Code:
+
+(require 'exwm)
+
+;;;; Buffer-local variables
+
+(defvar-local qutebrowser-exwm-win-id nil
+  "Contains the internal Qutebrowser window ID.")
+
+(defvar-local qutebrowser-exwm-keymode nil
+  "Contains the current keymode of the Qutebrowser window.")
+
+(defvar-local qutebrowser-exwm-hovered-url nil
+  "Contains the URL of the link currently hovered in Qutebrowser.")
+
+(defvar-local qutebrowser-exwm-current-url nil
+  "Contains the current URL of Qutebrowser.")
+
+(defvar-local qutebrowser-exwm-favicon nil
+  "Contains the favicon for each Qutebrowser buffer.")
+
+(defvar-local qutebrowser-exwm-current-search nil
+  "Contains the current search terms of Qutebrowser.")
+
+(defvar-local qutebrowser-exwm-recently-audible nil
+  "Contains the recently audible status of Qutebrowser.")
+
+(defvar-local qutebrowser-exwm-private nil
+  "Contains the private status of Qutebrowser.")
+
+(defvar-local qutebrowser-exwm-x-scroll-perc nil
+  "Contains the current x scroll percentage of Qutebrowser.")
+
+(defvar-local qutebrowser-exwm-y-scroll-perc nil
+  "Contains the current y scroll percentage of Qutebrowser.")
+
+(defvar qutebrowser-exwm-mode-map
+  (let ((map (make-sparse-keymap)))
+    map)
+  "Keymap used in `qutebrowser-exwm-mode' buffers.")
+
+;;;; Favicon management
+
+(defun qutebrowser-exwm--update-favicon (icon-file)
+  "Update the favicon.
+ICON-FILE is a temp-file containing the favicon.  Any previous ICON-FILE
+will be deleted."
+  (if (and (file-regular-p icon-file)
+           ;; Not empty
+           (> (nth 7 (file-attributes icon-file)) 0))
+      (when-let* ((image (create-image icon-file nil nil :height 16 :width 16 :ascent 'center)))
+        (let ((old-icon-file (image-property qutebrowser-exwm-favicon :file)))
+          (setq-local qutebrowser-exwm-favicon image)
+          (when old-icon-file
+            (delete-file old-icon-file))))
+    ;; Delete invalid/empty icon files
+    (delete-file icon-file)))
+
+(defun qutebrowser-exwm--delete-favicon-tempfile ()
+  "Deletes the tempfile associated with the favicon of current buffer."
+  (when-let* ((icon-file (image-property qutebrowser-exwm-favicon :file)))
+    (delete-file icon-file)))
+
+(add-hook 'kill-buffer-hook #'qutebrowser-exwm--delete-favicon-tempfile)
+
+;;;; Window information update
+
+(defun qutebrowser-exwm--update-window-info (window-info)
+  "Update buffer-local variables from WINDOW-INFO."
+  (when-let* ((x11-win-id (plist-get window-info :x11-win-id))
+              (buffer (exwm--id->buffer x11-win-id)))
+    (with-current-buffer buffer
+      (qutebrowser--with-plist window-info
+        (win-id (setq-local qutebrowser-exwm-win-id win-id))
+        (mode (setq-local qutebrowser-exwm-keymode mode))
+        (icon-file (qutebrowser-exwm--update-favicon icon-file))
+        (search (setq-local qutebrowser-exwm-current-search search))
+        (hover (when (string= hover "") (setq hover nil))
+               (setq-local qutebrowser-exwm-hovered-url hover))
+        (url (setq-local qutebrowser-exwm-current-url
+                         (unless (string-empty-p url) url))
+             (setq-local buffer-file-name
+                         (when (string-prefix-p "file://" url)
+                           (string-replace "file://" "" url))))
+        (x-scroll-perc (setq-local qutebrowser-exwm-x-scroll-perc x-scroll-perc))
+        (y-scroll-perc (setq-local qutebrowser-exwm-y-scroll-perc y-scroll-perc))
+        (private (setq-local qutebrowser-exwm-private private))
+        (recently-audible (setq-local qutebrowser-exwm-recently-audible recently-audible))))))
+
+;;;; Bookmark functions
+
+(defun qutebrowser-exwm-bookmark-make-record ()
+  "Make a bookmark record for Qutebrowser buffers."
+  `(,(buffer-name)
+    (handler . qutebrowser-bookmark-jump)
+    (url . ,(qutebrowser-exwm-buffer-url))))
+
+;;;; Utility functions
+
+(defun qutebrowser-exwm-revert-buffer-function (&rest _)
+  "Revert buffer function for Qutebrowser EXWM buffers.
+This function is used as the `revert-buffer-function' in
+`qutebrowser-exwm-mode', so that `revert-buffer' will reload the
+webpage."
+  (qutebrowser-send-commands ":reload"))
+
+(defun qutebrowser-exwm-find-buffer (url)
+  "Find the buffer showing URL."
+  (seq-find (lambda (buffer)
+              (string= url (qutebrowser-exwm-buffer-url buffer)))
+            (qutebrowser-exwm-buffer-list)))
+
+(defun qutebrowser-exwm--win-id->buffer (win-id)
+  "Find the buffer with the given internal WIN-ID."
+  (seq-find (lambda (buffer)
+              (eq win-id (buffer-local-value 'qutebrowser-exwm-win-id buffer)))
+            (qutebrowser-exwm-buffer-list)))
+
+(defun qutebrowser-exwm-p (&optional buffer)
+  "Return t if BUFFER is a Qutebrowser EXWM buffer."
+  (with-current-buffer (or buffer (current-buffer))
+    (and (bound-and-true-p exwm-class-name)
+         (string-equal "qutebrowser" exwm-class-name))))
+
+(defun qutebrowser-exwm-audible-p (&optional buffer)
+  "Return t if BUFFER is an audible Qutebrowser EXWM buffer."
+  (eq t
+      (buffer-local-value 'qutebrowser-exwm-recently-audible (or (get-buffer buffer) (current-buffer)))))
+
+(defun qutebrowser-exwm-private-p (&optional buffer)
+  "Return t if BUFFER is a private Qutebrowser EXWM buffer."
+  (eq t
+      (buffer-local-value 'qutebrowser-exwm-private (or (get-buffer buffer) (current-buffer)))))
+
+(defun qutebrowser-exwm-buffer-url (&optional buffer)
+  "Return the URL of BUFFER or the current buffer."
+  (buffer-local-value 'qutebrowser-exwm-current-url (or buffer (current-buffer))))
+
+(defun qutebrowser-exwm-buffer-list ()
+  "Return a list of all Qutebrowser buffers."
+  (seq-filter #'qutebrowser-exwm-p (buffer-list)))
+
+(defun qutebrowser-exwm-buffer-search (&optional input predicate)
+  "Return a propertized list of Qutebrowser buffers matching INPUT and PREDICATE."
+  (let* ((buffers (qutebrowser-exwm-buffer-list))
+         (input-matching-buffers
+          (qutebrowser--filter-list input
+                                    buffers
+                                    #'buffer-name
+                                    #'qutebrowser-exwm-buffer-url))
+         (matching-buffers (if predicate
+                               (seq-filter predicate input-matching-buffers)
+                             input-matching-buffers))
+         (matches (length matching-buffers)))
+    (setq qutebrowser-heading-buffer--with-count
+          (format qutebrowser-heading-buffer matches))
+    (mapcar (lambda (buffer)
+              (let* ((title (substring-no-properties (buffer-name buffer)))
+                     (url (or (qutebrowser-exwm-buffer-url buffer) " "))
+                     (win-id (buffer-local-value 'qutebrowser-exwm-win-id buffer))
+                     (icon (buffer-local-value 'qutebrowser-exwm-favicon buffer))
+
+                     (icon-string (propertize "" 'display icon)))
+                (propertize (qutebrowser--shorten-display-url url)
+			    :qutebrowser-candidate-type 'buffer
+			    :qutebrowser-buffer buffer
+                            :qutebrowser-title (if qutebrowser-launcher-show-icons
+						   (concat icon-string " " title)
+						 title))))
+            matching-buffers)))
+
+;;;; Minor mode
+
+;;;###autoload
+(define-minor-mode qutebrowser-exwm-mode
+  "Minor mode for Qutebrowser buffers in EXWM."
+  :lighter nil
+  :global nil
+  :keymap qutebrowser-exwm-mode-map
+  (if qutebrowser-exwm-mode
+      (progn
+        (qutebrowser-rpc-get-connection)
+        (setq-local revert-buffer-function
+                    #'qutebrowser-exwm-revert-buffer-function)
+        (setq-local bookmark-make-record-function
+                    #'qutebrowser-exwm-bookmark-make-record))
+    (kill-local-variable 'bookmark-make-record-function)
+    (kill-local-variable 'revert-buffer-function)))
+
+(defun qutebrowser-exwm-mode-maybe-enable ()
+  "Enable `qutebrowser-exwm-mode' if the buffer is a Qutebrowser buffer."
+  (when (qutebrowser-exwm-p)
+    (qutebrowser-exwm-mode 1)))
+
+;;;###autoload
+(define-globalized-minor-mode global-qutebrowser-exwm-mode
+  qutebrowser-exwm-mode
+  qutebrowser-exwm-mode-maybe-enable
+  (if global-qutebrowser-exwm-mode
+      (add-hook 'exwm-manage-finish-hook #'qutebrowser-exwm-mode-maybe-enable)
+    (remove-hook 'exwm-manage-finish-hook #'qutebrowser-exwm-mode-maybe-enable)))
+
+;;;; Advice
+
+;; Prevent Prescient history from being clogged up by web pages.
+(defun qutebrowser--advice-vertico-prescient (orig-fun &rest args)
+  "Exclude Qutebrowser buffer names and URLs from prescient history.
+The ORIG-FUN takes ARGS."
+  (let* ((selected-candidate (minibuffer-contents-no-properties))
+         (selected-buffer (get-buffer selected-candidate)))
+    (unless (or (qutebrowser-exwm-p selected-buffer)
+                (string-match-p "^https?://" selected-candidate))
+      (apply orig-fun args))))
+
+(with-eval-after-load 'vertico-prescient
+  (advice-add 'vertico-prescient--remember-minibuffer-contents :around
+              #'qutebrowser--advice-vertico-prescient))
+
+;; Add window info update hook
+(add-hook 'qutebrowser-update-window-info-functions #'qutebrowser-exwm--update-window-info)
+
+(provide 'qutebrowser-exwm)
+
+;;; qutebrowser-exwm.el ends here

--- a/qutebrowser.el
+++ b/qutebrowser.el
@@ -1,4 +1,4 @@
-;;; qutebrowser.el --- Qutebrowser integration with Emacs and EXWM     -*- lexical-binding: t; -*-
+;;; qutebrowser.el --- Qutebrowser integration with Emacs     -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2025 Lars Rustand.
 
@@ -23,28 +23,32 @@
 
 ;;; Commentary:
 
-;; This package adds enhanced support for Qutebrowser under EXWM,
-;; including integration with the Emacs bookmark system, buffer and
-;; history sources for Consult, a minor mode for Qutebrowser EXWM
-;; buffers, a minor mode providing theme synchronization between Emacs
-;; and Qutebrowser, and facilities for sending arbitrary commands to
+;; This package provides integration with Qutebrowser, including
+;; integration with the Emacs bookmark system, buffer and history
+;; sources for Consult, theme synchronization between Emacs and
+;; Qutebrowser, and facilities for sending arbitrary commands to
 ;; Qutebrowser from Emacs using IPC.
+;;
+;; For EXWM-specific integration (buffer tracking, favicons, minor
+;; mode for Qutebrowser EXWM buffers), load qutebrowser-exwm.el.
 
 ;;; Change Log:
 
 ;;; Code:
 
 (require 'sqlite)
-(require 'exwm)
 (require 'json)
 (require 'jsonrpc)
 (require 'color)
 (require 'cl-lib)
 
+;; EXWM support is available in qutebrowser-exwm.el
+;; Load it explicitly if you use EXWM: (require 'qutebrowser-exwm)
+
 ;;;; Customizable variables
 
 (defgroup qutebrowser nil
-  "EXWM enhancements for Qutebrowser."
+  "Emacs integration for Qutebrowser."
   :group 'external)
 
 (defcustom qutebrowser-theme-export-face-mappings
@@ -260,8 +264,9 @@ functions are called with a plist containing any information related to
 the signal that was emitted.  This plist usually contains X11-WIN-ID which
 is an X11 window ID of the window that emitted the signal.
 
-If the plist contains a X11-WIN-ID that can be resolved to an EXWM buffer,
-the hooks are run with that buffer as `current-buffer'.
+If qutebrowser-exwm is loaded and the plist contains a X11-WIN-ID that
+can be resolved to an EXWM buffer, the hooks are run with that buffer
+as `current-buffer'.
 
 The hooks are automatically dispatched from
 `qutebrowser-rpc--notification-dispatcher' based on the name of the
@@ -345,8 +350,7 @@ RECENTLY-AUDIBLE."
   :group 'qutebrowser-hooks
   :type 'hook)
 
-(defcustom qutebrowser-update-window-info-functions
-  '(qutebrowser-exwm--update-window-info)
+(defcustom qutebrowser-update-window-info-functions nil
   "Functions to run with updated information about windows.
 These functions should not be considered as hooks for any kind of event,
 and can be triggered both manually and automatically by various functions
@@ -371,7 +375,10 @@ The window information plist contains (one or more of) the following keys:
   - `:mode' is the KeyMode of the window.
   - `:recently-audible' is t if the window is currently or was recently audible.
   - `:x-scroll-perc' is the scroll percentage in the x direction.
-  - `:y-scroll-perc' is the scroll percentage in the y direction."
+  - `:y-scroll-perc' is the scroll percentage in the y direction.
+
+When qutebrowser-exwm is loaded, it adds `qutebrowser-exwm--update-window-info'
+to this hook."
   :group 'qutebrowser-hooks
   :type 'hook)
 
@@ -399,40 +406,6 @@ This list is used to identify running Qutebrowser processes.")
 (defvar qutebrowser--db-object nil
   "Contains a reference to the database connection.")
 
-(defvar-local qutebrowser-exwm-win-id nil
-  "Contains the internal Qutebrowser window ID.")
-
-(defvar-local qutebrowser-exwm-keymode nil)
-
-(defvar-local qutebrowser-exwm-hovered-url nil
-  "Contains the URL of the link currently hovered in Qutebrowser.")
-
-(defvar-local qutebrowser-exwm-current-url nil
-  "Contains the current URL of Qutebrowser.")
-
-(defvar-local qutebrowser-exwm-favicon nil
-  "Contains the favicon for each Qutebrowser buffer.")
-
-(defvar-local qutebrowser-exwm-current-search nil
-  "Contains the current search terms of Qutebrowser.")
-
-(defvar-local qutebrowser-exwm-recently-audible nil
-  "Contains the recently audible status of Qutebrowser.")
-
-(defvar-local qutebrowser-exwm-private nil
-  "Contains the private status of Qutebrowser.")
-
-(defvar-local qutebrowser-exwm-x-scroll-perc nil
-  "Contains the current x scroll percentage of Qutebrowser.")
-
-(defvar-local qutebrowser-exwm-y-scroll-perc nil
-  "Contains the current y scroll percentage of Qutebrowser.")
-
-(defvar qutebrowser-exwm-mode-map
-  (let ((map (make-sparse-keymap)))
-    map)
-  "Keymap used in `qutebrowser-exwm-mode' buffers.")
-
 (defvar qutebrowser-config-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-c") #'qutebrowser-config-source-file)
@@ -445,28 +418,6 @@ This list is used to identify running Qutebrowser processes.")
 (defconst qutebrowser--package-directory (file-name-directory (or load-file-name
                                                                   buffer-file-name)))
 ;;;; Hook functions
-
-(defun qutebrowser-exwm--update-favicon (icon-file)
-  "Update the favicon.
-ICON-FILE is a temp-file containing the favicon.  Any previous ICON-FILE
-will be deleted."
-  (if (and (file-regular-p icon-file)
-           ;; Not empty
-           (> (nth 7 (file-attributes icon-file)) 0))
-      (when-let* ((image (create-image icon-file nil nil :height 16 :width 16 :ascent 'center)))
-        (let ((old-icon-file (image-property qutebrowser-exwm-favicon :file)))
-          (setq-local qutebrowser-exwm-favicon image)
-          (when old-icon-file
-            (delete-file old-icon-file))))
-    ;; Delete invalid/empty icon files
-    (delete-file icon-file)))
-
-(defun qutebrowser-exwm--delete-favicon-tempfile ()
-  "Deletes the tempfile associated with the favicon of current buffer."
-  (when-let* ((icon-file (image-property qutebrowser-exwm-favicon :file)))
-    (delete-file icon-file)))
-
-(add-hook 'kill-buffer-hook #'qutebrowser-exwm--delete-favicon-tempfile)
 
 (defmacro qutebrowser--with-plist-key (key plist &rest body)
   "Execute BODY if KEY exists in PLIST, with KEY's value bound.
@@ -492,28 +443,6 @@ and BODY is one or more forms to execute if KEY is in PLIST."
                    `(qutebrowser--with-plist-key ,key ,plist
                       ,@body)))
                clauses)))
-
-(defun qutebrowser-exwm--update-window-info (window-info)
-  "Update buffer-local variables from WINDOW-INFO."
-  (when-let* ((x11-win-id (plist-get window-info :x11-win-id))
-              (buffer (exwm--id->buffer x11-win-id)))
-    (with-current-buffer buffer
-      (qutebrowser--with-plist window-info
-        (win-id (setq-local qutebrowser-exwm-win-id win-id))
-        (mode (setq-local qutebrowser-exwm-keymode mode))
-        (icon-file (qutebrowser-exwm--update-favicon icon-file))
-        (search (setq-local qutebrowser-exwm-current-search search))
-        (hover (when (string= hover "") (setq hover nil))
-               (setq-local qutebrowser-exwm-hovered-url hover))
-        (url (setq-local qutebrowser-exwm-current-url
-                         (unless (string-empty-p url) url))
-             (setq-local buffer-file-name
-                         (when (string-prefix-p "file://" url)
-                           (string-replace "file://" "" url))))
-        (x-scroll-perc (setq-local qutebrowser-exwm-x-scroll-perc x-scroll-perc))
-        (y-scroll-perc (setq-local qutebrowser-exwm-y-scroll-perc y-scroll-perc))
-        (private (setq-local qutebrowser-exwm-private private))
-        (recently-audible (setq-local qutebrowser-exwm-recently-audible recently-audible))))))
 
 
 ;;;; History database functions
@@ -571,41 +500,6 @@ Return up to LIMIT results."
     ('private-window "-p")
     ('auto "")))
 
-(defun qutebrowser-exwm-find-buffer (url)
-  "Find the buffer showing URL."
-  (seq-find (lambda (buffer)
-              (string= url (qutebrowser-exwm-buffer-url buffer)))
-            (qutebrowser-exwm-buffer-list)))
-
-(defun qutebrowser-exwm--win-id->buffer (win-id)
-  (seq-find (lambda (buffer)
-              (eq win-id (buffer-local-value 'qutebrowser-exwm-win-id buffer)))
-            (qutebrowser-exwm-buffer-list)))
-
-(defun qutebrowser-exwm-p (&optional buffer)
-  "Return t if BUFFER is a Qutebrowser EXWM buffer."
-  (with-current-buffer (or buffer (current-buffer))
-    (string-equal "qutebrowser"
-                  exwm-class-name)))
-
-(defun qutebrowser-exwm-audible-p (&optional buffer)
-  "Return t if BUFFER is an audible Qutebrowser EXWM buffer."
-  (eq t
-      (buffer-local-value 'qutebrowser-exwm-recently-audible (or (get-buffer buffer) (current-buffer)))))
-
-(defun qutebrowser-exwm-private-p (&optional buffer)
-  "Return t if BUFFER is an audible Qutebrowser EXWM buffer."
-  (eq t
-      (buffer-local-value 'qutebrowser-exwm-private (or (get-buffer buffer) (current-buffer)))))
-
-(defun qutebrowser-exwm-buffer-url (&optional buffer)
-  "Return the URL of BUFFER or the current buffer."
-  (buffer-local-value 'qutebrowser-exwm-current-url (or buffer (current-buffer))))
-
-(defun qutebrowser-exwm-buffer-list ()
-  "Return a list of all Qutebrowser buffers."
-  (seq-filter #'qutebrowser-exwm-p (buffer-list)))
-
 (defun qutebrowser--shorten-display-string (string max-length)
   "Shorten STRING by making the end invisible."
   (let ((string (substring string)) ; Copy it to avoid modifying the original
@@ -623,12 +517,6 @@ Return up to LIMIT results."
   (qutebrowser--shorten-display-string title qutebrowser-title-display-length))
 
 ;;;; Bookmark functions
-
-(defun qutebrowser-bookmark-make-record ()
-  "Make a bookmark record for Qutebrowser buffers."
-  `(,(buffer-name)
-    (handler . qutebrowser-bookmark-jump)
-    (url . ,(qutebrowser-exwm-buffer-url))))
 
 (defun qutebrowser-bookmark-url (bookmark)
   "Return the URL that BOOKMARK is pointing to."
@@ -693,35 +581,6 @@ all the words in INPUT in any of the fields retrieved by FIELD-GETTERS."
                             :qutebrowser-candidate-type 'bookmark
                             :qutebrowser-title bookmark)))
             matching-bookmarks)))
-
-(defun qutebrowser-exwm-buffer-search (&optional input predicate)
-  "Return a propertized list of Qutebrowser buffers matching INPUT and PREDICATE."
-  (let* ((buffers (qutebrowser-exwm-buffer-list))
-         (input-matching-buffers
-           (qutebrowser--filter-list input
-                                     buffers
-                                     #'buffer-name
-                                     #'qutebrowser-exwm-buffer-url))
-         (matching-buffers (if predicate
-                               (seq-filter predicate input-matching-buffers)
-                             input-matching-buffers))
-         (matches (length matching-buffers)))
-    (setq qutebrowser-heading-buffer--with-count
-          (format qutebrowser-heading-buffer matches))
-    (mapcar (lambda (buffer)
-              (let* ((title (substring-no-properties (buffer-name buffer)))
-                     (url (or (qutebrowser-exwm-buffer-url buffer) " "))
-                     (win-id (buffer-local-value 'qutebrowser-exwm-win-id buffer))
-                     (icon (buffer-local-value 'qutebrowser-exwm-favicon buffer))
-
-                     (icon-string (propertize "" 'display icon)))
-                (propertize (qutebrowser--shorten-display-url url)
-			    :qutebrowser-candidate-type 'buffer
-			    :qutebrowser-buffer buffer
-                            :qutebrowser-title (if qutebrowser-launcher-show-icons
-						   (concat icon-string " " title)
-						 title))))
-            matching-buffers)))
 
 
 (defun qutebrowser-command-search (&optional input)
@@ -813,7 +672,8 @@ than `qutebrowser-url-display-length'."
             (setq current-candidates
                   (append
                    (qutebrowser-command-search string)
-                   (qutebrowser-exwm-buffer-search string)
+                   (when (fboundp 'qutebrowser-exwm-buffer-search)
+                     (qutebrowser-exwm-buffer-search string))
                    (qutebrowser-bookmark-search string)
                    (qutebrowser--history-search string))))
         current-candidates))))
@@ -940,22 +800,6 @@ Set initial completion input to INITIAL."
 Set initial completion input to INITIAL."
   (interactive)
   (qutebrowser-launcher initial default 'private-window))
-
-;;;; Advice
-
-;; Prevent Prescient history from being clogged up by web pages.
-(defun qutebrowser--advice-vertico-prescient (orig-fun &rest args)
-  "Exclude Qutebrowser buffer names and URLs from prescient history.
-The ORIG-FUN takes ARGS."
-  (let* ((selected-candidate (minibuffer-contents-no-properties))
-         (selected-buffer (get-buffer selected-candidate)))
-    (unless (or (qutebrowser-exwm-p selected-buffer)
-                (string-match-p "^https?://" selected-candidate))
-      (apply orig-fun args))))
-
-(with-eval-after-load 'vertico-prescient
-  (advice-add 'vertico-prescient--remember-minibuffer-contents :around
-              #'qutebrowser--advice-vertico-prescient))
 
 ;;;; RPC functions
 
@@ -1147,8 +991,8 @@ CONN is the `jsonrpc-connection' the request was received on.
 METHOD is the method that was called.
 PARAMS are the parameters given."
   (let* ((hook (intern-soft (format "qutebrowser-on-%s-functions" method)))
-         (x11-win-id (plist-get params :x11-win-id))
-         (buffer (exwm--id->buffer x11-win-id)))
+         (buffer (and (fboundp 'exwm--id->buffer)
+                      (exwm--id->buffer (plist-get params :x11-win-id)))))
     (with-current-buffer (or buffer (current-buffer))
       (run-hook-with-args 'qutebrowser-update-window-info-functions params)
       (run-hook-with-args hook params))))
@@ -1161,11 +1005,10 @@ METHOD is the method that was called.
 PARAMS are the parameters given."
   (cl-case method
     (eval
-     (with-current-buffer
-         (or (and (fboundp 'exwm--id->buffer)
-                  (exwm--id->buffer (plist-get params :x11-win-id)))
-             (current-buffer))
-       (eval (read (plist-get params :code)))))
+     (let ((buffer (and (fboundp 'exwm--id->buffer)
+                        (exwm--id->buffer (plist-get params :x11-win-id)))))
+       (with-current-buffer (or buffer (current-buffer))
+         (eval (read (plist-get params :code))))))
     (t (message "Receive request from QB: %s, %s" method params)
        "Responding from Emacs!")))
 
@@ -1233,7 +1076,8 @@ last visible window."
     (when (and (numberp current-prefix-arg)
                (not (plist-member params :count)))
       (plist-put params :count current-prefix-arg))
-    (when (and qutebrowser-exwm-win-id
+    (when (and (boundp 'qutebrowser-exwm-win-id)
+               qutebrowser-exwm-win-id
                (not (plist-member params :win-id)))
       (plist-put params :win-id qutebrowser-exwm-win-id))
     (qutebrowser-rpc-async-request
@@ -1271,7 +1115,8 @@ TARGET specifies where to open it, or `qutebrowser-default-open-target'
 if nil."
   (let* ((target (cond
                   (target)
-                  ((qutebrowser-exwm-p) qutebrowser-default-open-target)
+                  ((and (fboundp 'qutebrowser-exwm-p) (qutebrowser-exwm-p))
+                   qutebrowser-default-open-target)
                   (qutebrowser-fifo qutebrowser-default-open-target)
                   ;; We don't want to accidentally replace an existing
                   ;; window/tab when opening a URL in 'auto target
@@ -1336,18 +1181,12 @@ Creates a temporary file and sources it in Qutebrowser using the
   (interactive)
   (qutebrowser-send-commands ":undo --window"))
 
-(defun qutebrowser-revert-buffer-function (&rest _)
-  "Revert buffer function for Qutebrowser EXWM buffers.
-This function is used as the `revert-buffer-function' in
-`qutebrowser-exwm-mode', so that `revert-buffer' will reload the
-webpage."
-  (qutebrowser-send-commands ":reload"))
-
 (defun qutebrowser--list-anchors ()
   "List webpage anchors."
   (let* ((js "Array.from(document.querySelectorAll('[href^=\"#\"]'))
                    .map((elem)=> elem.hash);")
-         (params `(:js-code ,js :win-id ,qutebrowser-exwm-win-id)))
+         (params `(:js-code ,js :win-id ,(when (boundp 'qutebrowser-exwm-win-id)
+                                           qutebrowser-exwm-win-id))))
 
     (seq-filter (lambda (elem) (and elem (not (string-blank-p elem))))
                 (seq-uniq
@@ -1472,35 +1311,6 @@ It runs the `%s' RPC method in Qutebrowser.\n\n" method-name)
 
 ;;;; Modes
 
-;;;###autoload
-(define-minor-mode qutebrowser-exwm-mode
-  "Minor mode for Qutebrowser buffers in EXWM."
-  :lighter nil
-  :global nil
-  :keymap qutebrowser-exwm-mode-map
-  (if qutebrowser-exwm-mode
-      (progn
-        (qutebrowser-rpc-get-connection)
-        (setq-local revert-buffer-function
-                    #'qutebrowser-revert-buffer-function)
-        (setq-local bookmark-make-record-function
-                    #'qutebrowser-bookmark-make-record))
-    (kill-local-variable 'bookmark-make-record-function)
-    (kill-local-variable 'revert-buffer-function)))
-
-(defun qutebrowser-exwm-mode-maybe-enable ()
-  "Enable `qutebrowser-exwm-mode' if the buffer is a Qutebrowser buffer."
-  (when (qutebrowser-exwm-p)
-    (qutebrowser-exwm-mode 1)))
-
-;;;###autoload
-(define-globalized-minor-mode global-qutebrowser-exwm-mode
-  qutebrowser-exwm-mode
-  qutebrowser-exwm-mode-maybe-enable
-  (if global-qutebrowser-exwm-mode
-      (add-hook 'exwm-manage-finish-hook #'qutebrowser-exwm-mode-maybe-enable)
-    (remove-hook 'exwm-manage-finish-hook #'qutebrowser-exwm-mode-maybe-enable)))
-
 ;;;; Theme export mode
 (defun qutebrowser-theme-export--face-mappings ()
   "Write `qutebrowser-theme-export-face-mappings' values."
@@ -1574,7 +1384,8 @@ It runs the `%s' RPC method in Qutebrowser.\n\n" method-name)
   "Return non-nil if Qutebrowser is running."
   (when (or (qutebrowser-rpc-connected-p)
             (qutebrowser--get-process-pid)
-            (qutebrowser-exwm-buffer-list))
+            (and (fboundp 'qutebrowser-exwm-buffer-list)
+                 (qutebrowser-exwm-buffer-list)))
     t))
 
 ;;;; Config mode


### PR DESCRIPTION
I am experimenting with EXWM's successor for wayland (https://codeberg.org/ezemtsov/ewm) and therefore removing EXWM dependency from my config. I've verified the changed code works both with and without exwm, but give it a try yourself first. Fixes #41